### PR TITLE
change service node port

### DIFF
--- a/pkg/apis/constants/constants.go
+++ b/pkg/apis/constants/constants.go
@@ -53,17 +53,18 @@ const (
 	SysAdminProject  = "system"
 	DefaultDomain    = "Default"
 
+	// note: service node port in range 30000-32767
 	KeystoneDB         = "keystone"
 	KeystoneDBUser     = "keystone"
-	KeystonePublicPort = 5000
-	KeystoneAdminPort  = 35357
+	KeystonePublicPort = 30500
+	KeystoneAdminPort  = 30357
 
 	GlanceDB           = "glance"
 	GlanceDBUser       = "glance"
 	GlanceAdminUser    = "glance"
 	GlanceAdminProject = SysAdminProject
-	GlanceRegistryPort = 9191
-	GlanceAPIPort      = 9292
+	GlanceRegistryPort = 30191
+	GlanceAPIPort      = 30292
 	ServiceNameGlance  = "glance"
 	ServiceTypeGlance  = "image"
 	GlanceDataStore    = "/opt/cloud/workspace/data/glance"
@@ -75,64 +76,66 @@ const (
 
 	RegionAdminUser    = "regionadmin"
 	RegionAdminProject = SysAdminProject
-	RegionPort         = 8889
-	SchedulerPort      = 8897
+	RegionPort         = 30888
+	SchedulerPort      = 30887
 	RegionDB           = "yunioncloud"
 	RegionDBUser       = "yunioncloud"
 
 	HostAdminUser    = "hostadmin"
 	HostAdminProject = SysAdminProject
-	HostPort         = 8885
+	// Host not use node port
+	HostPort = 8885
 
 	BaremetalAdminUser    = "baremetal"
 	BaremetalAdminProject = SysAdminProject
-	BaremetalPort         = 8879
+	// Baremetal not use node port
+	BaremetalPort = 8879
 
 	KubeServerAdminUser = "kubeserver"
-	KubeServerPort      = 8443
+	KubeServerPort      = 30442
 	KubeServerDB        = "kubeserver"
 	KubeServerDBUser    = "kubeserver"
 
 	WebconsoleAdminUser    = "webconsole"
 	WebconsoleAdminProject = SysAdminProject
-	WebconsolePort         = 8899
+	WebconsolePort         = 30899
 
 	LoggerAdminUser = "loggeradmin"
-	LoggerPort      = 9999
+	LoggerPort      = 30999
 	LoggerDB        = "yunionlogger"
 	LoggerDBUser    = "yunionlogger"
 
 	APIGatewayAdminUser = "yunionapi"
-	APIGatewayPort      = 9300
-	APIWebsocketPort    = 10443
+	APIGatewayPort      = 30300
+	APIWebsocketPort    = 30443
 
 	YunionAgentAdminUser = "yunionagent"
-	YunionAgentPort      = 9899
+	YunionAgentPort      = 30898
 	YunionAgentDB        = "yunionagent"
 	YunionAgentDBUser    = "yunionagent"
 
 	YunionConfAdminUser = "yunionconf"
-	YunionConfPort      = 9889
+	YunionConfPort      = 30889
 	YunionConfDB        = "yunionconf"
 	YunionConfDBUser    = "yunionconf"
 
 	NotifyAdminUser = "notify"
-	NotifyPort      = 7777
+	NotifyPort      = 30777
 	NotifyDB        = "notify"
 	NotifyDBUser    = "notify"
 
-	InfluxdbPort      = 8086
+	InfluxdbPort      = 30086
 	InfluxdbDataStore = "/var/lib/influxdb"
 
 	AnsibleServerAdminUser    = "ansibleadmin"
 	AnsibleServerAdminProject = SysAdminProject
-	AnsibleServerPort         = 8890
+	AnsibleServerPort         = 30890
 	AnsibleServerDB           = "yunionansible"
 	AnsibleServerDBUser       = "yunionansible"
 
 	CloudnetAdminUser    = "cloudnetadmin"
 	CloudnetAdminProject = SysAdminProject
-	CloudnetPort         = 8891
+	CloudnetPort         = 30891
 	CloudnetDB           = "yunioncloudnet"
 	CloudnetDBUser       = "yunioncloudnet"
 

--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -29,6 +29,7 @@ const (
 	DefaultVersion             = "latest"
 	DefaultOnecloudRegion      = "region0"
 	DefaultOnecloudZone        = "zone0"
+	DefaultOnecloudWire        = "bcast0"
 	DefaultImageRepository     = "registry.hub.docker.com/yunion"
 	DefaultVPCId               = "default"
 	DefaultGlanceStoreageSize  = "100G"

--- a/pkg/controller/onecloud_control.go
+++ b/pkg/controller/onecloud_control.go
@@ -476,11 +476,11 @@ func (c *regionComponent) SystemInit() error {
 	if err := ensureZone(s, zone); err != nil {
 		return errors.Wrapf(err, "create zone %s", zone)
 	}
-	/*if err := ensureAdminNetwork(s, oc.Spec.Zone, localCfg.ManagementNetInterface); err != nil {
-		return errors.Wrapf(err, "create admin network")
-	}*/
 	if err := ensureRegionZone(s, region, zone); err != nil {
 		return errors.Wrapf(err, "create region-zone %s-%s", region, zone)
+	}
+	if err := ensureWire(s, oc.Spec.Zone, v1alpha1.DefaultOnecloudWire, 1000); err != nil {
+		return errors.Wrapf(err, "create default wire")
 	}
 	if err := initScheduleData(s); err != nil {
 		return errors.Wrap(err, "init sched data")

--- a/pkg/manager/component/apigateway.go
+++ b/pkg/manager/component/apigateway.go
@@ -56,6 +56,7 @@ func (m *apiGatewayManager) getConfigMap(oc *v1alpha1.OnecloudCluster, cfg *v1al
 	}
 	SetOptionsServiceTLS(&opt.BaseOptions)
 	SetServiceCommonOptions(&opt.CommonOptions, oc, cfg.APIGateway)
+	opt.Port = constants.APIGatewayPort
 	opt.WsPort = constants.APIWebsocketPort
 
 	return m.newServiceConfigMap(v1alpha1.APIGatewayComponentType, oc, opt), nil

--- a/pkg/manager/component/keystone.go
+++ b/pkg/manager/component/keystone.go
@@ -73,6 +73,7 @@ func (m *keystoneManager) getConfigMap(oc *v1alpha1.OnecloudCluster, clusterCfg 
 
 	opt.BootstrapAdminUserPassword = oc.Spec.Keystone.BootstrapPassword
 	opt.AdminPort = constants.KeystoneAdminPort
+	opt.Port = constants.KeystonePublicPort
 
 	return m.newServiceConfigMap(v1alpha1.KeystoneComponentType, oc, opt), nil
 }
@@ -112,12 +113,12 @@ func (m *keystoneManager) getDeployment(oc *v1alpha1.OnecloudCluster, _ *v1alpha
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          "public",
-						ContainerPort: int32(5000),
+						ContainerPort: int32(constants.KeystonePublicPort),
 						Protocol:      corev1.ProtocolTCP,
 					},
 					{
 						Name:          "admin",
-						ContainerPort: int32(35357),
+						ContainerPort: int32(constants.KeystoneAdminPort),
 						Protocol:      corev1.ProtocolTCP,
 					},
 				},

--- a/pkg/manager/component/web.go
+++ b/pkg/manager/component/web.go
@@ -220,6 +220,14 @@ server {
 
         proxy_read_timeout 86400;
     }
+
+    location /baremetal-prepare/ {
+        # Some basic cache-control for static files to be sent to the browser
+        root /opt/cloud/yunion/baremetal/;
+        expires max;
+        add_header Pragma public;
+        add_header Cache-Control "public, must-revalidate, proxy-revalidate";
+    }
 }
 `
 )

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -21,6 +21,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"yunion.io/x/onecloud-operator/pkg/apis/constants"
 
@@ -87,6 +88,16 @@ func (c *ConfigManager) CreateOrUpdate(oc *v1alpha1.OnecloudCluster) (*v1alpha1.
 func newClusterConfig() *v1alpha1.OnecloudClusterConfig {
 	config := &v1alpha1.OnecloudClusterConfig{}
 	return fillClusterConfigDefault(config)
+}
+
+func GetClusterConfigByClient(k8sCli kubernetes.Interface, oc *v1alpha1.OnecloudCluster) (*v1alpha1.OnecloudClusterConfig, error) {
+	cfgMapName := controller.ClusterConfigMapName(oc)
+	ns := oc.GetNamespace()
+	obj, err := k8sCli.CoreV1().ConfigMaps(ns).Get(cfgMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return newClusterConfigFromConfigMapNoDefault(obj)
 }
 
 func newClusterConfigFromConfigMapNoDefault(cfgMap *corev1.ConfigMap) (*v1alpha1.OnecloudClusterConfig, error) {


### PR DESCRIPTION
之前 ocadm 创建的集群 nodePort range 设置范围太大了，容易造成端口冲突，现在使用 k8s 默认的 nodePort 区间 3000-32767
/cc @swordqiu @wanyaoqi @yousong 