### PR TITLE
Automated cherry pick of #42: host: mark those host services as unneeded on host system

### DIFF
--- a/pkg/manager/component/host.go
+++ b/pkg/manager/component/host.go
@@ -75,6 +75,10 @@ func (m *hostManager) newHostPrivilegedDaemonSet(
 					ImagePullPolicy: dsSpec.ImagePullPolicy,
 					Env: []corev1.EnvVar{
 						corev1.EnvVar{
+							Name:  "HOST_SYSTEM_SERVICES_OFF",
+							Value: "host-deployer,host_sdnagent",
+						},
+						corev1.EnvVar{
 							Name:  "OVN_CONTAINER_IMAGE_TAG",
 							Value: v1alpha1.DefaultOvnImageTag,
 						},


### PR DESCRIPTION
Cherry pick of #42 on release/3.1.

#42: host: mark those host services as unneeded on host system