### PR TITLE
Automated cherry pick of #50: defaults: openvswitch: default to using 2.9.6-2

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -44,7 +44,7 @@ const (
 
 	DefaultOvnVersion   = "2.9.6"
 	DefaultOvnImageName = "openvswitch"
-	DefaultOvnImageTag  = DefaultOvnVersion + "-1"
+	DefaultOvnImageTag  = DefaultOvnVersion + "-2"
 
 	DefaultInfluxdbImageVersion = "1.7.7"
 )

--- a/pkg/manager/component/host.go
+++ b/pkg/manager/component/host.go
@@ -75,6 +75,16 @@ func (m *hostManager) newHostPrivilegedDaemonSet(
 					ImagePullPolicy: dsSpec.ImagePullPolicy,
 					Env: []corev1.EnvVar{
 						corev1.EnvVar{
+							Name: "HOST_OVN_SOUTH_DATABASE",
+							Value: fmt.Sprintf("tcp:%s:%d",
+								controller.NewClusterComponentName(
+									oc.GetName(),
+									v1alpha1.OvnNorthComponentType,
+								),
+								constants.OvnSouthDbPort,
+							),
+						},
+						corev1.EnvVar{
 							Name:  "HOST_SYSTEM_SERVICES_OFF",
 							Value: "host-deployer,host_sdnagent",
 						},

--- a/pkg/manager/component/utils.go
+++ b/pkg/manager/component/utils.go
@@ -466,7 +466,7 @@ func (h *VolumeHelper) GetVolumeMounts() []corev1.VolumeMount {
 }
 
 func (h *VolumeHelper) addOvsVolumes() *VolumeHelper {
-	volSrcType := corev1.HostPathDirectory
+	volSrcType := corev1.HostPathDirectoryOrCreate
 	h.volumes = append(h.volumes,
 		corev1.Volume{
 			Name: "var-run-openvswitch",


### PR DESCRIPTION
Cherry pick of #50 on release/3.1.

#50: defaults: openvswitch: default to using 2.9.6-2