### PR TITLE
Automated cherry pick of #79: host: run dir use bidirectional mount

### DIFF
--- a/pkg/manager/component/utils.go
+++ b/pkg/manager/component/utils.go
@@ -618,9 +618,10 @@ func NewHostVolume(
 			MountPath: "/dev",
 		},
 		{
-			Name:      "run",
-			ReadOnly:  false,
-			MountPath: "/var/run",
+			Name:             "run",
+			ReadOnly:         false,
+			MountPath:        "/var/run",
+			MountPropagation: &bidirectional,
 		},
 		{
 			Name:      "sys",


### PR DESCRIPTION
Cherry pick of #79 on release/3.0.

#79: host: run dir use bidirectional mount