### PR TITLE
bugfix：宿主机监控没有默认值注入的函数

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -176,6 +176,10 @@ func SetDefaults_OnecloudClusterSpec(obj *OnecloudClusterSpec, isEE bool) {
 	SetDefaults_CronJobSpec(&obj.CloudmonReportServer,
 		getImage(obj.ImageRepository, obj.CloudmonReportServer.Repository, APIGatewayComponentTypeEE,
 			obj.CloudmonReportServer.ImageName, obj.Version, obj.APIGateway.Tag))
+
+	SetDefaults_CronJobSpec(&obj.CloudmonReportHost,
+		getImage(obj.ImageRepository, obj.CloudmonReportHost.Repository, APIGatewayComponentTypeEE,
+			obj.CloudmonReportHost.ImageName, obj.Version, obj.APIGateway.Tag))
 }
 
 func SetDefaults_Mysql(obj *Mysql) {


### PR DESCRIPTION
这个 PR 实现什么功能/修复什么问题:
bugfix：宿主机监控没有默认值注入的函数

是否需要 backport 到之前的 release 分支:
- release/3.0
- release/3.1
- release/3.2