### PR TITLE
Automated cherry pick of #154: bugfix：宿主机监控没有默认值注入的函数

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -176,6 +176,10 @@ func SetDefaults_OnecloudClusterSpec(obj *OnecloudClusterSpec, isEE bool) {
 	SetDefaults_CronJobSpec(&obj.CloudmonReportServer,
 		getImage(obj.ImageRepository, obj.CloudmonReportServer.Repository, APIGatewayComponentTypeEE,
 			obj.CloudmonReportServer.ImageName, obj.Version, obj.APIGateway.Tag))
+
+	SetDefaults_CronJobSpec(&obj.CloudmonReportHost,
+		getImage(obj.ImageRepository, obj.CloudmonReportHost.Repository, APIGatewayComponentTypeEE,
+			obj.CloudmonReportHost.ImageName, obj.Version, obj.APIGateway.Tag))
 }
 
 func SetDefaults_Mysql(obj *Mysql) {


### PR DESCRIPTION
Cherry pick of #154 on release/3.2.

#154: bugfix：宿主机监控没有默认值注入的函数