### PR TITLE
Automated cherry pick of #158: etcd cluster default use version 3.4.6

### DIFF
--- a/pkg/apis/constants/constants.go
+++ b/pkg/apis/constants/constants.go
@@ -296,7 +296,7 @@ const (
 	EtcdPeerPort              = 2380
 	EtcdImageName             = "etcd"
 	EtcdDefaultClusterSize    = 3
-	EtcdImageVersion          = "3.3.10"
+	EtcdImageVersion          = "3.4.6"
 	EtcdDefaultRequestTimeout = 5 * time.Second
 	EtcdDefaultDialTimeout    = 3 * time.Second
 	BusyboxImageName          = "busybox"


### PR DESCRIPTION
Cherry pick of #158 on release/3.2.

#158: etcd cluster default use version 3.4.6