### PR TITLE
Automated cherry pick of #170: not register azure classic host data

### DIFF
--- a/pkg/controller/onecloud_control.go
+++ b/pkg/controller/onecloud_control.go
@@ -786,9 +786,11 @@ func initScheduleData(s *mcclient.ClientSession) error {
 	if err := registerSchedSameProjectCloudprovider(s); err != nil {
 		return err
 	}
-	if err := registerSchedAzureClassicHost(s); err != nil {
-		return err
-	}
+	/*
+	 *if err := registerSchedAzureClassicHost(s); err != nil {
+	 *    return err
+	 *}
+	 */
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of #170 on release/3.2.

#170: not register azure classic host data