### PR TITLE
fix: Change api prefix '/api/v1' as 'api/v1'

### DIFF
--- a/pkg/manager/component/notify.go
+++ b/pkg/manager/component/notify.go
@@ -67,7 +67,7 @@ func (m *notifyManager) getPhaseControl(man controller.ComponentManager) control
 	return controller.NewRegisterEndpointComponent(
 		man, v1alpha1.NotifyComponentType,
 		constants.ServiceNameNotify, constants.ServiceTypeNotify,
-		constants.NotifyPort, "/api/v1")
+		constants.NotifyPort, "api/v1")
 }
 
 type NotifyPluginBaseConfig struct {


### PR DESCRIPTION
这样会把 endpoint-list 的 api，从 ‘//api/v1’ 变为 ‘/api/v1’。
这只会影响展示效果，不会影响实际的请求。因为请求uri默认会把多的 '/' 合并