### PR TITLE
fix: apigateway totp should default on

### DIFF
--- a/pkg/manager/component/apigateway.go
+++ b/pkg/manager/component/apigateway.go
@@ -47,7 +47,7 @@ type apiOptions struct {
 	options.CommonOptions
 	WsPort      int  `default:"10443"`
 	ShowCaptcha bool `default:"true"`
-	EnableTotp  bool `default:"false"`
+	EnableTotp  bool `default:"true"`
 }
 
 func (m *apiGatewayManager) getCloudUser(cfg *v1alpha1.OnecloudClusterConfig) *v1alpha1.CloudUser {


### PR DESCRIPTION
修正：apigateway从3.3开始应该默认开启TOTP

/cc @zexi 