### PR TITLE
Automated cherry pick of #220: fix: apigateway totp should default on

### DIFF
--- a/pkg/manager/component/apigateway.go
+++ b/pkg/manager/component/apigateway.go
@@ -47,7 +47,7 @@ type apiOptions struct {
 	options.CommonOptions
 	WsPort      int  `default:"10443"`
 	ShowCaptcha bool `default:"true"`
-	EnableTotp  bool `default:"false"`
+	EnableTotp  bool `default:"true"`
 }
 
 func (m *apiGatewayManager) getCloudUser(cfg *v1alpha1.OnecloudClusterConfig) *v1alpha1.CloudUser {


### PR DESCRIPTION
Cherry pick of #220 on release/3.3.

#220: fix: apigateway totp should default on