### PR TITLE
Automated cherry pick of #283: regiondns: configmap: quash trailing spaces

### DIFF
--- a/pkg/manager/component/regiondns.go
+++ b/pkg/manager/component/regiondns.go
@@ -38,10 +38,12 @@ const (
         fallthrough .
     }
 
-    {{range .Proxies}}
+    {{- range .Proxies }}
+
     proxy {{.From}} {{.To}} {
     }
-    {{end}}
+    {{- end }}
+
     log {
         class error
     }


### PR DESCRIPTION
Cherry pick of #283 on release/3.3.

#283: regiondns: configmap: quash trailing spaces