### PR TITLE
Automated cherry pick of #300: monitor: alert for host_raid adapter should >= 0

### DIFF
--- a/pkg/controller/onecloud_control.go
+++ b/pkg/controller/onecloud_control.go
@@ -1191,7 +1191,7 @@ func (c monitorComponent) getInitInfo() map[string]onecloud.CommonAlertTem {
 		Measurement: "host_raid",
 		Field:       []string{"adapter"},
 		FieldFunc:   "last",
-		Comparator:  "==",
+		Comparator:  ">=",
 		Threshold:   0,
 		Filters: genHostRaidStatusFilter(
 			"offline",


### PR DESCRIPTION
Cherry pick of #300 on release/3.4.

#300: monitor: alert for host_raid adapter should >= 0