### PR TITLE
modify commonalert init policy 

### DIFF
--- a/pkg/util/onecloud/onecloud.go
+++ b/pkg/util/onecloud/onecloud.go
@@ -610,6 +610,41 @@ func GetCommonAlertOfSys(session *mcclient.ClientSession) ([]jsonutils.JSONObjec
 }
 
 func CreateCommonAlert(s *mcclient.ClientSession, tem CommonAlertTem) (jsonutils.JSONObject, error) {
+	commonAlert := newCommonalertQuery(tem)
+	input := monitorapi.CommonAlertCreateInput{
+		CommonMetricInputQuery: monitorapi.CommonMetricInputQuery{
+			MetricQuery: []*monitorapi.CommonAlertQuery{&commonAlert},
+		},
+		AlertCreateInput: monitorapi.AlertCreateInput{
+			Name:  tem.Name,
+			Level: "important",
+		},
+		Recipients: []string{monitorapi.CommonAlertDefaultRecipient},
+		AlertType:  monitorapi.CommonAlertSystemAlertType,
+		Scope:      "system",
+	}
+
+	param := jsonutils.Marshal(&input)
+	return modules.CommonAlertManager.Create(s, param)
+}
+
+func UpdateCommonAlert(s *mcclient.ClientSession, tem CommonAlertTem, id string) (jsonutils.JSONObject, error) {
+	commonAlert := newCommonalertQuery(tem)
+	input := monitorapi.CommonAlertUpdateInput{
+		CommonMetricInputQuery: monitorapi.CommonMetricInputQuery{
+			MetricQuery: []*monitorapi.CommonAlertQuery{&commonAlert},
+		},
+	}
+	param := jsonutils.Marshal(&input)
+	param.(*jsonutils.JSONDict).Set("force_update", jsonutils.JSONTrue)
+	return modules.CommonAlertManager.Update(s, id, param)
+}
+
+func DeleteCommonAlert(s *mcclient.ClientSession, ids []string) {
+	modules.CommonAlertManager.BatchDelete(s, ids, jsonutils.NewDict())
+}
+
+func newCommonalertQuery(tem CommonAlertTem) monitorapi.CommonAlertQuery {
 	metricQ := monitorapi.MetricQuery{
 		Alias:        "",
 		Tz:           "",
@@ -656,20 +691,5 @@ func CreateCommonAlert(s *mcclient.ClientSession, tem CommonAlertTem) (jsonutils
 	if tem.FieldOpt != "" {
 		commonAlert.FieldOpt = monitorapi.CommonAlertFieldOpt_Division
 	}
-
-	input := monitorapi.CommonAlertCreateInput{
-		CommonMetricInputQuery: monitorapi.CommonMetricInputQuery{
-			MetricQuery: []*monitorapi.CommonAlertQuery{&commonAlert},
-		},
-		AlertCreateInput: monitorapi.AlertCreateInput{
-			Name:  tem.Name,
-			Level: "important",
-		},
-		Recipients: []string{monitorapi.CommonAlertDefaultRecipient},
-		AlertType:  monitorapi.CommonAlertSystemAlertType,
-		Scope:      "system",
-	}
-
-	param := jsonutils.Marshal(&input)
-	return modules.CommonAlertManager.Create(s, param)
+	return commonAlert
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题:**
1.对已经存在的策略，进行update操作。
2.对operator中没有init的策略，自动进行delete。

**是否需要 backport 到之前的 release 分支:**

- release/3.4

- release/3.5

/cc @zexi 