### PR TITLE
Automated cherry pick of #317: 限制 client_header_timeout 时长，预防慢攻击

### DIFF
--- a/pkg/manager/component/web.go
+++ b/pkg/manager/component/web.go
@@ -85,6 +85,8 @@ server {
     client_header_buffer_size 16k;
     client_max_body_size 8m;
     large_client_header_buffers 2 16k;
+    client_body_timeout 20s;
+    client_header_timeout 20s;
 
 {{.EditionConfig}}
 


### PR DESCRIPTION
Cherry pick of #317 on release/3.5.

#317: 限制 client_header_timeout 时长，预防慢攻击