### PR TITLE
Automated cherry pick of #320: 限制 client_body_timeout 时长，预防慢攻击

### DIFF
--- a/pkg/manager/component/web.go
+++ b/pkg/manager/component/web.go
@@ -124,6 +124,7 @@ server {
     }
 
     location /api {
+        client_body_timeout 60s;
         proxy_pass {{.APIGatewayURL}};
         proxy_redirect   off;
         proxy_set_header Host $host;
@@ -137,6 +138,7 @@ server {
     }
 
     location /api/v1/imageutils/upload {
+        client_body_timeout 60s;
         proxy_pass {{.APIGatewayURL}};
         client_max_body_size 0;
         proxy_http_version 1.1;
@@ -148,6 +150,7 @@ server {
     }
 
     location /api/v1/s3uploads {
+        client_body_timeout 60s;
         proxy_pass {{.APIGatewayURL}};
         client_max_body_size 0;
         proxy_http_version 1.1;


### PR DESCRIPTION
Cherry pick of #320 on release/3.5.

#320: 限制 client_body_timeout 时长，预防慢攻击