### PR TITLE
Automated cherry pick of #329: ce edition should not deploy meter

### DIFF
--- a/pkg/manager/component/meter.go
+++ b/pkg/manager/component/meter.go
@@ -38,6 +38,9 @@ func newMeterManager(man *ComponentManager) manager.Manager {
 }
 
 func (m *meterManager) Sync(oc *v1alpha1.OnecloudCluster) error {
+	if !IsEnterpriseEdition(oc) {
+		return nil
+	}
 	return syncComponent(m, oc, oc.Spec.Meter.Disable)
 }
 


### PR DESCRIPTION
Cherry pick of #329 on release/3.5.

#329: ce edition should not deploy meter