### PR TITLE
fix(telegraf): fix collect disk measurements

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -53,7 +53,7 @@ const (
 	DefaultInfluxdbImageVersion = "1.7.7"
 
 	DefaultTelegrafImageName     = "telegraf"
-	DefaultTelegrafImageTag      = "release-1.5.2"
+	DefaultTelegrafImageTag      = "release-1.5.3"
 	DefaultTelegrafInitImageName = "telegraf-init"
 	DefaultTelegrafInitImageTag  = "release-1.5.2"
 	DefaultTelegrafRaidImageName = "telegraf-raid-plugin"


### PR DESCRIPTION
In the container environments, disk measurements is not
correct, because of is a different mount namespace.
Mount host rootfs to container and set env HOST_MOUNT_PREFIX
to indicate telegraf where is the data from.

cherrypick: release/3.6

/cc @zexi 

