### PR TITLE
bugfix(suggestion): fix err when suggestion syncConfigMap

### DIFF
--- a/pkg/manager/component/suggestion.go
+++ b/pkg/manager/component/suggestion.go
@@ -27,14 +27,6 @@ func (m *suggestionManager) Sync(oc *v1alpha1.OnecloudCluster) error {
 	return syncComponent(m, oc, oc.Spec.Suggestion.Disable)
 }
 
-func (m *suggestionManager) getDBConfig(cfg *v1alpha1.OnecloudClusterConfig) *v1alpha1.DBConfig {
-	return &cfg.Monitor.DB
-}
-
-func (m *suggestionManager) getCloudUser(cfg *v1alpha1.OnecloudClusterConfig) *v1alpha1.CloudUser {
-	return &cfg.Monitor.CloudUser
-}
-
 func (m *suggestionManager) getPhaseControl(man controller.ComponentManager) controller.PhaseControl {
 	return controller.NewRegisterEndpointComponent(
 		man, v1alpha1.SuggestionComponentType,


### PR DESCRIPTION
1.修改suggestion.go 中func:getDBConfig()和getCloudUser()返回

**是否需要 backport 到之前的 release 分支:**

- release/3.6

/cc @zexi 