### PR TITLE
apigateway: cors: rename spec field name to corsHosts

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/types.go
+++ b/pkg/apis/onecloud/v1alpha1/types.go
@@ -619,7 +619,7 @@ type APIGatewaySpec struct {
 	DeploymentSpec
 
 	// Allowed hostname in Origin header.  Default to allow all
-	CorsHosts []string `json:"cors_hosts"`
+	CorsHosts []string `json:"corsHosts"`
 }
 
 type RegionSpec struct {


### PR DESCRIPTION
Ref https://github.com/yunionio/onecloud-operator/pull/389

/cc @zexi @swordqiu

