### PR TITLE
Automated cherry pick of #392: apigateway: cors: rename spec field name to corsHosts

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/types.go
+++ b/pkg/apis/onecloud/v1alpha1/types.go
@@ -619,7 +619,7 @@ type APIGatewaySpec struct {
 	DeploymentSpec
 
 	// Allowed hostname in Origin header.  Default to allow all
-	CorsHosts []string `json:"cors_hosts"`
+	CorsHosts []string `json:"corsHosts"`
 }
 
 type RegionSpec struct {


### PR DESCRIPTION
Cherry pick of #392 on release/3.6.

#392: apigateway: cors: rename spec field name to corsHosts