### PR TITLE
Automated cherry pick of #1478: feat: set openclaw image to v2026.3.24-20260327.0

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -92,7 +92,7 @@ const (
 const (
 	DefaultVllmImageTag = "v0.15.1"
 
-	DefaultOpenclawImageTag = "v2026.3.12-20260326.2"
+	DefaultOpenclawImageTag = "v2026.3.24-20260327.0"
 )
 
 const (


### PR DESCRIPTION
Cherry pick of #1478 on release/4.0.2.

#1478: feat: set openclaw image to v2026.3.24-20260327.0