### PR TITLE
Automated cherry pick of #1487: fix(monitor-stack): skip Sync when component is disabled

### DIFF
--- a/pkg/manager/component/monitor_stack.go
+++ b/pkg/manager/component/monitor_stack.go
@@ -61,6 +61,10 @@ func (m *monitorStackManager) IsDisabled(oc *v1alpha1.OnecloudCluster) bool {
 }
 
 func (m *monitorStackManager) Sync(oc *v1alpha1.OnecloudCluster) error {
+	if m.IsDisabled(oc) {
+		return nil
+	}
+
 	clustercfg, err := m.configer.GetClusterConfig(oc)
 	if err != nil {
 		return errors.Wrap(err, "get cluster config for grafana")


### PR DESCRIPTION
Cherry pick of #1487 on release/3.11.

#1487: fix(monitor-stack): skip Sync when component is disabled