### PR TITLE
Automated cherry pick of #1498: fix(component): skip anti-eviction for k8s clusters below 1.20

### DIFF
--- a/pkg/manager/component/component.go
+++ b/pkg/manager/component/component.go
@@ -1284,6 +1284,9 @@ func (m *ComponentManager) applyHostComponentAntiEviction(ds *apps.DaemonSet) {
 	if ds == nil {
 		return
 	}
+	if !m.clusterVersion.IsGreatOrEqualThanV120() {
+		return
+	}
 	ds.Spec.Template.Spec.PriorityClassName = "system-node-critical"
 }
 


### PR DESCRIPTION
Cherry pick of #1498 on master.

#1498: fix(component): skip anti-eviction for k8s clusters below 1.20