### PR TITLE
Automated cherry pick of #1519: feat: set default telegraf image to release-1.36.4-6

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -76,7 +76,7 @@ const (
 	DefaultVictoriaMetricsImageVersion = "v1.129.1-1"
 
 	DefaultTelegrafImageName     = "telegraf"
-	DefaultTelegrafImageTag      = "release-1.36.4-4"
+	DefaultTelegrafImageTag      = "release-1.36.4-6"
 	DefaultTelegrafInitImageName = "telegraf-init"
 	DefaultTelegrafInitImageTag  = "release-1.36-1"
 	DefaultTelegrafRaidImageName = "telegraf-raid-plugin"


### PR DESCRIPTION
Cherry pick of #1519 on release/4.0.3.

#1519: feat: set default telegraf image to release-1.36.4-6