### PR TITLE
Automated cherry pick of #1544: fix(web): remove /ai reverse proxy location from nginx config

### DIFF
--- a/pkg/service-init/component/web.go
+++ b/pkg/service-init/component/web.go
@@ -158,18 +158,6 @@ server {
         proxy_read_timeout 600;
     }
 
-    location ^~ /ai {
-        proxy_pass {{.AiProxyURL}};
-        proxy_redirect   off;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-        proxy_http_version 1.1;
-        proxy_buffering off;
-        proxy_read_timeout 600;
-    }
-
     location /api/s/image/v1/images {
         client_max_body_size 0;
         client_body_timeout 300;


### PR DESCRIPTION
Cherry pick of #1544 on master.

#1544: fix(web): remove /ai reverse proxy location from nginx config