### PR TITLE
feat(component): enable aiproxy and mcp-server for CMP product version

### DIFF
--- a/pkg/manager/component/aiproxy.go
+++ b/pkg/manager/component/aiproxy.go
@@ -44,6 +44,7 @@ func newAiProxyManager(man *ComponentManager) manager.ServiceManager {
 func (m *aiProxyManager) getProductVersions() []v1alpha1.ProductVersion {
 	return []v1alpha1.ProductVersion{
 		v1alpha1.ProductVersionFullStack,
+		v1alpha1.ProductVersionCMP,
 		v1alpha1.ProductVersionEdge,
 		v1alpha1.ProductVersionAI,
 	}

--- a/pkg/manager/component/mcp-server.go
+++ b/pkg/manager/component/mcp-server.go
@@ -39,6 +39,8 @@ func newMcpServerManager(man *ComponentManager) manager.ServiceManager {
 func (m *mcpServerManager) getProductVersions() []v1alpha1.ProductVersion {
 	return []v1alpha1.ProductVersion{
 		v1alpha1.ProductVersionFullStack,
+		v1alpha1.ProductVersionCMP,
+		v1alpha1.ProductVersionEdge,
 		v1alpha1.ProductVersionAI,
 	}
 }


### PR DESCRIPTION
Also enable mcp-server on Edge so AI-related services are available beyond FullStack/AI.