### PR TITLE
Automated cherry pick of #1554: fix(mcp-server): support mcp-server-ee

### DIFF
--- a/pkg/apis/constants/constants.go
+++ b/pkg/apis/constants/constants.go
@@ -61,6 +61,9 @@ const (
 
 	RegionCEImageName = "region"
 	RegionEEImageName = "region-ee"
+
+	McpServerCEImageName = "mcp-server"
+	McpServerEEImageName = "mcp-server-ee"
 )
 
 const (

--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -215,7 +215,6 @@ func SetDefaults_OnecloudClusterSpec(obj *OnecloudClusterSpec, isEE bool, isEEOr
 		ExtdbComponentType:           nHP(&obj.Extdb.DeploymentSpec, useHyperImage),
 		BillingComponentType:         nHP(&obj.Billing.DeploymentSpec, useHyperImage),
 		LLMComponentType:             nHP(&obj.LLM.DeploymentSpec, useHyperImage),
-		McpServerComponentType:       nHP(&obj.McpServer.DeploymentSpec, useHyperImage),
 		AiProxyComponentType:         nHP(&obj.AiProxy.DeploymentSpec, useHyperImage),
 	} {
 		SetDefaults_DeploymentSpec(spec.DeploymentSpec, getImage(
@@ -230,8 +229,9 @@ func SetDefaults_OnecloudClusterSpec(obj *OnecloudClusterSpec, isEE bool, isEEOr
 
 	// CE or EE parts
 	for cType, spec := range map[ComponentType]*hyperImagePair{
-		CloudmuxComponentType: nHP(obj.Cloudmux.ToDeploymentSpec(), false),
-		CloudmonComponentType: nHP(&obj.Cloudmon.DeploymentSpec, useHyperImage),
+		CloudmuxComponentType:  nHP(obj.Cloudmux.ToDeploymentSpec(), false),
+		CloudmonComponentType:  nHP(&obj.Cloudmon.DeploymentSpec, useHyperImage),
+		McpServerComponentType: nHP(&obj.McpServer.DeploymentSpec, useHyperImage),
 	} {
 		SetDefaults_DeploymentSpec(spec.DeploymentSpec,
 			getEditionImage(

--- a/pkg/manager/component/mcp-server.go
+++ b/pkg/manager/component/mcp-server.go
@@ -58,6 +58,12 @@ func (m *mcpServerManager) GetServiceName() string {
 }
 
 func (m *mcpServerManager) Sync(oc *v1alpha1.OnecloudCluster) error {
+	isEE := IsEnterpriseEdition(oc)
+	imageName := oc.Spec.McpServer.ImageName
+	// 版本在 CE/EE 间切换时清空 ImageName，让 defaults 按 edition 重新选 mcp-server / mcp-server-ee
+	if (imageName == constants.McpServerCEImageName && isEE) || (imageName == constants.McpServerEEImageName && !isEE) {
+		oc.Spec.McpServer.ImageName = ""
+	}
 	return syncComponent(m, oc, "")
 }
 


### PR DESCRIPTION
Cherry pick of #1554 on release/4.0.

#1554: fix(mcp-server): support mcp-server-ee