### PR TITLE
Automated cherry pick of #1557: chore: bump default telegraf image tag to release-1.36.4-8

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -73,7 +73,7 @@ const (
 	DefaultVictoriaMetricsImageVersion = "v1.129.1-1"
 
 	DefaultTelegrafImageName     = "telegraf"
-	DefaultTelegrafImageTag      = "release-1.36.4-6"
+	DefaultTelegrafImageTag      = "release-1.36.4-8"
 	DefaultTelegrafInitImageName = "telegraf-init"
 	DefaultTelegrafInitImageTag  = "release-1.36-1"
 	DefaultTelegrafRaidImageName = "telegraf-raid-plugin"


### PR DESCRIPTION
Cherry pick of #1557 on master.

#1557: chore: bump default telegraf image tag to release-1.36.4-8